### PR TITLE
Changing to an UberJAR as there is conflict when running in Kafka Con…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,7 @@
         <junit.surefire.plugin.version>1.3.2</junit.surefire.plugin.version>
         <surefire.version>2.22.2</surefire.version>
         <failsafe.version>2.22.2</failsafe.version>
+        <maven-shade-plugin.version>3.5.1</maven-shade-plugin.version>
     </properties>
     <licenses>
         <license>
@@ -215,29 +216,32 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>io.confluent</groupId>
-                <artifactId>kafka-connect-maven-plugin</artifactId>
-                <version>0.11.2</version>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>${maven-shade-plugin.version}</version>
+                <configuration>
+                    <filters>
+                        <filter>
+                            <artifact>*:*</artifact>
+                            <excludes>
+                                <exclude>META-INF/*.SF</exclude>
+                                <exclude>META-INF/*.DSA</exclude>
+                                <exclude>META-INF/*.RSA</exclude>
+                                <exclude>META-INF/SIG-*</exclude>
+                            </excludes>
+                        </filter>
+                    </filters>
+                </configuration>
                 <executions>
                     <execution>
-                        <id>hub</id>
+                        <phase>package</phase>
                         <goals>
-                            <goal>kafka-connect</goal>
+                            <goal>shade</goal>
                         </goals>
                         <configuration>
-                            <confluentControlCenterIntegration>true</confluentControlCenterIntegration>
-                            <documentationUrl>https://jcustenborder.github.io/kafka-connect-documentation/projects/kafka-connect-transform-xml/</documentationUrl>
-                            <componentTypes>
-                                <componentType>transform</componentType>
-                            </componentTypes>
-                            <ownerUsername>wvella</ownerUsername>
-                            <tags>
-                                <tag>Transform</tag>
-                                <tag>Xml</tag>
-                            </tags>
-                            <title>Xml Transformation</title>
-                            <supportUrl>${pom.issueManagement.url}</supportUrl>
-                            <supportSummary>Support provided through community involvement.</supportSummary>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                            </transformers>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
Running this SMT in a Connector (tested with `confluentinc/cp-server-connect:7.7.0` Docker Image) with a package built with the `kafka-connect-maven-plugin` maven plugin, produces the following error:

`org.apache.kafka.connect.errors.ConnectException: java.lang.NullPointerException: Cannot invoke "java.lang.reflect.Method.invoke(Object, Object[])" because "com.sun.xml.bind.v2.runtime.reflect.opt.Injector.defineClass" is null`

Therefore, the only way I could get this work is to package the SMT in an **uber-jar**, including its dependencies and to shade (i.e. rename) the packages of some of the dependencies. 

Also, since this SMT imports classes in the `javax` package, this plugin **must be added** to both the `plugin.path` and the `CLASSPATH` of the Connect Worker. This appears to be an issue with the classloading isolation in Kafka Connect as described [here](https://docs.confluent.io/platform/current/connect/userguide.html#install-a-plugin). If you don't add this plugin to the `CLASSPATH`, you will see an error like this the Kafka Connect Worker logs:

`org.apache.kafka.connect.errors.ConnectException: java.lang.AssertionError: javax.xml.bind.JAXBException: Implementation of JAXB-API has not been found on module path or classpath.`